### PR TITLE
Fixed compiling with newer/latest libssl

### DIFF
--- a/ovpn.c
+++ b/ovpn.c
@@ -101,8 +101,8 @@ static void ctl_init(ovpn_t *ovpn) {
 	
 	pthread_mutex_init(&ctl->state_mtx, NULL);
 	
-	HMAC_CTX_init(&ctl->hmac_tx);
-	HMAC_CTX_init(&ctl->hmac_rx);
+	ctl->hmac_tx = HMAC_CTX_new();
+	ctl->hmac_rx = HMAC_CTX_new();
 	
 	/* initialize key contexts */
 	
@@ -113,11 +113,11 @@ static void ctl_init(ovpn_t *ovpn) {
 		
 		pthread_rwlock_init(&key->lock, NULL);
 		
-		HMAC_CTX_init(&key->hmac_rx);
-		HMAC_CTX_init(&key->hmac_tx);
+		key->hmac_rx = HMAC_CTX_new();
+		key->hmac_tx = HMAC_CTX_new();
 	
-		EVP_CIPHER_CTX_init(&key->evp_dec);
-		EVP_CIPHER_CTX_init(&key->evp_enc);
+		EVP_CIPHER_CTX_init(key->evp_dec);
+		EVP_CIPHER_CTX_init(key->evp_enc);
 	}
 	
 	/* socketpair for notifying Lua about state changes

--- a/ovpn.h
+++ b/ovpn.h
@@ -39,10 +39,10 @@ struct prng_s {
 };
 
 struct key_s {
-	EVP_CIPHER_CTX evp_dec;
-	EVP_CIPHER_CTX evp_enc;
-	HMAC_CTX hmac_tx;
-	HMAC_CTX hmac_rx;
+	EVP_CIPHER_CTX *evp_dec;
+	EVP_CIPHER_CTX *evp_enc;
+	HMAC_CTX *hmac_tx;
+	HMAC_CTX *hmac_rx;
 	uint32_t rx_pid;
 	uint32_t tx_pid;
 	pthread_rwlock_t lock;
@@ -81,8 +81,8 @@ struct ctl_s {
 	
 	int ctl_sock[2];
 
-	HMAC_CTX hmac_tx;
-	HMAC_CTX hmac_rx;
+	HMAC_CTX *hmac_tx;
+	HMAC_CTX *hmac_rx;
 
 	int key_id;
 	struct ctl_state_s tx_state;

--- a/ovpn_crypto.c
+++ b/ovpn_crypto.c
@@ -70,9 +70,9 @@ static int encrypt(chains_t *chains, node_t *n) {
 	pid = ++key->tx_pid; /* packet ID */
 	*((uint32_t *)ib->ptr) = htonl(pid);
 	
-	res=EVP_EncryptInit_ex(&key->evp_enc, NULL, NULL, NULL, iv_ptr);
-	EVP_EncryptUpdate(&key->evp_enc, od_ptr, &c_len, ib->ptr, ib->len);
-	EVP_EncryptFinal_ex(&key->evp_enc, od_ptr+c_len, &f_len);
+	res=EVP_EncryptInit_ex(key->evp_enc, NULL, NULL, NULL, iv_ptr);
+	EVP_EncryptUpdate(key->evp_enc, od_ptr, &c_len, ib->ptr, ib->len);
+	EVP_EncryptFinal_ex(key->evp_enc, od_ptr+c_len, &f_len);
 	
 	pthread_rwlock_unlock(&key->lock);
 	
@@ -118,9 +118,9 @@ static int decrypt(chains_t *chains, node_t *n) {
 		return 0;
 	}
 
-	EVP_DecryptInit_ex(&key->evp_dec, NULL, NULL, NULL, iv);
-	EVP_DecryptUpdate(&key->evp_dec, ob->ptr, &c_len, ib->ptr, ib->len);
-	EVP_DecryptFinal_ex(&key->evp_dec, ob->ptr + c_len, &f_len);	
+	EVP_DecryptInit_ex(key->evp_dec, NULL, NULL, NULL, iv);
+	EVP_DecryptUpdate(key->evp_dec, ob->ptr, &c_len, ib->ptr, ib->len);
+	EVP_DecryptFinal_ex(key->evp_dec, ob->ptr + c_len, &f_len);	
 
 	update_stats(&crypto->dec_stats, c_len + f_len);
 	

--- a/ovpn_ctl.c
+++ b/ovpn_ctl.c
@@ -48,9 +48,9 @@ int ovpn_ctl_getsock(ovpn_t *ovpn) {
 
 void ovpn_ctl_config(ovpn_t *ovpn, const uint8_t *hmac_txkey, const uint8_t *hmac_rxkey) {
 	struct ctl_s *ctl = &ovpn->ctl;
-	int res = HMAC_Init_ex(&ctl->hmac_tx, hmac_txkey, 20, EVP_sha1(), NULL);
+	int res = HMAC_Init_ex(ctl->hmac_tx, hmac_txkey, 20, EVP_sha1(), NULL);
 	assert(res == 1);
-	res = HMAC_Init_ex(&ctl->hmac_rx, hmac_rxkey, 20, EVP_sha1(), NULL);
+	res = HMAC_Init_ex(ctl->hmac_rx, hmac_rxkey, 20, EVP_sha1(), NULL);
 	assert(res == 1);
 }
 
@@ -180,7 +180,7 @@ static int ctl_putheader(struct ctl_s *ctl, buf_t *ob, uint8_t op) {
 	
 	hdr->ack_len 	= n_acks;
 	
-	ctl_hmac(&ctl->hmac_tx, hdr, ob->len, 0);
+	ctl_hmac(ctl->hmac_tx, hdr, ob->len, 0);
 	
 	res = ob->len;
 	
@@ -289,7 +289,7 @@ int ovpn_process_ctl(chains_t *chains, struct ctl_s *ctl, buf_t *ib) {
 	buf_consume(ib, sizeof(struct ovpn_hdr_s));
 	
 	/* check HMAC */
-	res = ctl_hmac(&ctl->hmac_rx, hdr, orig_len, 1);
+	res = ctl_hmac(ctl->hmac_rx, hdr, orig_len, 1);
 	if(res)
 		goto drop;
 	
@@ -406,14 +406,14 @@ void ovpn_ctl_setkeys(ovpn_t *ovpn, const uint8_t *keys) {
 	/* update key */
 	pthread_rwlock_wrlock(&key->lock);
 	
-	res = EVP_EncryptInit_ex(&key->evp_enc, EVP_aes_256_cbc(), NULL, keys, NULL);
+	res = EVP_EncryptInit_ex(key->evp_enc, EVP_aes_256_cbc(), NULL, keys, NULL);
 	assert(res == 1);
-	res = HMAC_Init_ex(&key->hmac_tx, keys+64, 20, EVP_sha1(), NULL);
+	res = HMAC_Init_ex(key->hmac_tx, keys+64, 20, EVP_sha1(), NULL);
 	assert(res == 1);
 	
-	res = EVP_DecryptInit_ex(&key->evp_dec, EVP_aes_256_cbc(), NULL, keys+128, NULL);
+	res = EVP_DecryptInit_ex(key->evp_dec, EVP_aes_256_cbc(), NULL, keys+128, NULL);
 	assert(res == 1);
-	res = HMAC_Init_ex(&key->hmac_rx, keys+192, 20, EVP_sha1(), NULL);
+	res = HMAC_Init_ex(key->hmac_rx, keys+192, 20, EVP_sha1(), NULL);
 	assert(res == 1);
 	
 	pthread_rwlock_unlock(&key->lock);

--- a/ovpn_hmac.c
+++ b/ovpn_hmac.c
@@ -46,7 +46,7 @@ static int work_hash(chains_t *chains, node_t *n) {
 	}
 	
 	buf_prepend(ib, 20);
-	res = hmac(&key->hmac_tx, src, src_len, ib->ptr+1);
+	res = hmac(key->hmac_tx, src, src_len, ib->ptr+1);
 	
 	pthread_rwlock_unlock(&key->lock);
 	
@@ -78,7 +78,7 @@ static int work_verify(chains_t *chains, node_t *n) {
 		goto drop;
 	}
 	
-	res = hmac(&key->hmac_rx, ib->ptr+1, ib->len-1, hmac_buf);
+	res = hmac(key->hmac_rx, ib->ptr+1, ib->len-1, hmac_buf);
 	
 	pthread_rwlock_unlock(&key->lock);
 	


### PR DESCRIPTION
Please thoroughly review this pull request. I merely
confirmed that it unbreaks compilation, but couldn't try it
out myself yet. Since HMAC_CTX is now a pointer, we should
also try to free it when appropriate:

```
HMAC_CTX_free(somectx);
```

I also assume this may break backwards compatibility with
older versions of libssl, but could not confirm it yet.

Fixes #3.

Edited: Mixed up the ticket number, sorry. This is obviously supposed to fix #3, not #2.