### PR TITLE
Fixed crash due to missing EVP_CIPHER_CTX_new initialization

### DIFF
--- a/ovpn.c
+++ b/ovpn.c
@@ -115,7 +115,9 @@ static void ctl_init(ovpn_t *ovpn) {
 		
 		key->hmac_rx = HMAC_CTX_new();
 		key->hmac_tx = HMAC_CTX_new();
-	
+		key->evp_dec = EVP_CIPHER_CTX_new();
+		key->evp_enc = EVP_CIPHER_CTX_new();
+
 		EVP_CIPHER_CTX_init(key->evp_dec);
 		EVP_CIPHER_CTX_init(key->evp_enc);
 	}


### PR DESCRIPTION
Since `evp_enc` and `evp_dec` are pointers now, we need to initialize them - of course.