### PR TITLE
Added error handling around tlskey/ca parsing

### DIFF
--- a/frivpn_client.lua
+++ b/frivpn_client.lua
@@ -185,10 +185,20 @@ function vpn:new(cfg, tun)
 	self.__index = self
 
 	local tun_fd
-	local txkey, rxkey = load_tlskeys(cfg.tlskeys, cfg.tlskeys_ids)
+	local status, txkey, rxkey = pcall(load_tlskeys, cfg.tlskeys, cfg.tlskeys_ids)
+	if not status then
+		print(string.format("Could not load TLS keys from %s", cfg.tlskeys))
+		os.exit(1)
+	end
+
+	local status, ca = pcall(readfile, cfg.cafile)
+	if not status then
+		print(string.format("Could not load CA cert from %s", cfg.cafile))
+		os.exit(1)
+	end
 
 	res.ssl_params = {
-		ca = readfile(cfg.cafile),
+		ca = ca,
 		txkey = txkey,
 		rxkey = rxkey,
 	}


### PR DESCRIPTION
I'm not too happy with `vpn:new` deciding to directly call `os.exit` here. Since it's not a reusable method in a module it's probably fine, but maybe returning an error from this method and handling the print & exit up the stack would be cleaner.